### PR TITLE
Add support for Implicit FTPS

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration.java
+++ b/src/main/java/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration.java
@@ -72,6 +72,7 @@ public class BapFtpHostConfiguration extends BPHostConfiguration<BapFtpClient, O
     private final boolean disableMakeNestedDirs;
     private final boolean disableRemoteVerification;
     private boolean useFtpOverTls;
+    private boolean useImplicitTls;
     private String trustedCertificate;
 
     @DataBoundConstructor
@@ -89,6 +90,11 @@ public class BapFtpHostConfiguration extends BPHostConfiguration<BapFtpClient, O
     @DataBoundSetter
     public void setUseFtpOverTls(final boolean useFtpOverTls) {
         this.useFtpOverTls = useFtpOverTls;
+    }
+
+    @DataBoundSetter
+    public void setUseImplicitTls(final boolean useImplicitTls) {
+        this.useImplicitTls = useImplicitTls;
     }
 
     @DataBoundSetter
@@ -121,6 +127,10 @@ public class BapFtpHostConfiguration extends BPHostConfiguration<BapFtpClient, O
         return useFtpOverTls;
     }
 
+    public boolean isUseImplicitTls() {
+        return useImplicitTls;
+    }
+
     public String getTrustedCertificate() {
         return trustedCertificate;
     }
@@ -140,7 +150,7 @@ public class BapFtpHostConfiguration extends BPHostConfiguration<BapFtpClient, O
 
     public FTPClient createFTPClient() throws GeneralSecurityException, FileNotFoundException, IOException {
         if (useFtpOverTls) {
-            FTPSClient c = new FTPSClient(false);
+            FTPSClient c = new FTPSClient(useImplicitTls);
 
             KeyStore ts = KeyStore.getInstance(KeyStore.getDefaultType());
             String trustStorePath = System.getProperty("javax.net.ssl.trustStore");

--- a/src/main/java/jenkins/plugins/publish_over_ftp/descriptor/BapFtpHostConfigurationDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ftp/descriptor/BapFtpHostConfigurationDescriptor.java
@@ -78,12 +78,12 @@ public class BapFtpHostConfigurationDescriptor extends Descriptor<BapFtpHostConf
             @QueryParameter final int timeout, @QueryParameter final boolean useActiveData,
             @QueryParameter final String controlEncoding, @QueryParameter final boolean disableMakeNestedDirs,
             @QueryParameter final boolean disableRemoteVerification, @QueryParameter final boolean useFtpOverTls,
-            @QueryParameter final String trustedCertificate) {
+            @QueryParameter final boolean useImplicitTls, @QueryParameter final String trustedCertificate) {
         final BapFtpPublisherPlugin.Descriptor pluginDescriptor = Jenkins.getInstance().getDescriptorByType(
                 BapFtpPublisherPlugin.Descriptor.class);
         return pluginDescriptor.doTestConnection(name, hostname, username, encryptedPassword, remoteRootDir, port,
                 timeout, useActiveData, controlEncoding, disableMakeNestedDirs, disableRemoteVerification,
-                useFtpOverTls, trustedCertificate);
+                useFtpOverTls, useImplicitTls, trustedCertificate);
     }
 
     public jenkins.plugins.publish_over.view_defaults.HostConfiguration.Messages getCommonFieldNames() {

--- a/src/main/java/jenkins/plugins/publish_over_ftp/descriptor/BapFtpPublisherPluginDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ftp/descriptor/BapFtpPublisherPluginDescriptor.java
@@ -133,11 +133,13 @@ public class BapFtpPublisherPluginDescriptor extends BuildStepDescriptor<Publish
     public FormValidation doTestConnection(final String name, final String hostname, final String username,
             final String encryptedPassword, final String remoteRootDir, final int port, final int timeout,
             final boolean useActiveData, final String controlEncoding, final boolean disableMakeNestedDirs,
-            final boolean disableRemoteVerification, final boolean useFtpOverTls, final String trustedCertificate) {
+            final boolean disableRemoteVerification, final boolean useFtpOverTls, final boolean useImplicitTls,
+            final String trustedCertificate) {
         final BapFtpHostConfiguration hostConfig = new BapFtpHostConfiguration(name, hostname, username,
                 encryptedPassword, remoteRootDir, port, timeout, useActiveData, controlEncoding,
                 disableMakeNestedDirs, disableRemoteVerification);
         hostConfig.setUseFtpOverTls(useFtpOverTls);
+        hostConfig.setUseImplicitTls(useImplicitTls);
         hostConfig.setTrustedCertificate(trustedCertificate);
         return validateConnection(hostConfig, createDummyBuildInfo());
     }

--- a/src/main/resources/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration/config.jelly
+++ b/src/main/resources/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration/config.jelly
@@ -65,11 +65,14 @@
             <f:entry title="${%useFtpOverTls}" field="useFtpOverTls">
               <f:checkbox/>
             </f:entry>
+            <f:entry title="${%useImplicitTls}" field="useImplicitTls">
+              <f:checkbox/>
+            </f:entry>
             <f:entry title="${%trustedCertificate}" field="trustedCertificate">
               <f:textarea/>
             </f:entry>
           </f:advanced>
           <f:validateButton title="${m.test_title()}" progress="${m.test_progress()}" method="testConnection"
-                            with="name,hostname,username,encryptedPassword,remoteRootDir,port,timeout,useActiveData,controlEncoding,disableRemoteVerification,useFtpOverTls,trustedCertificate"/>
+                            with="name,hostname,username,encryptedPassword,remoteRootDir,port,timeout,useActiveData,controlEncoding,disableRemoteVerification,useFtpOverTls,useImplicitTls,trustedCertificate"/>
 
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration/config.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration/config.properties
@@ -27,4 +27,5 @@ controlEncoding=Control encoding
 disableMakeNestedDirs=Don''t make nested dirs
 disableRemoteVerification=Disables Remote Verification
 useFtpOverTls=Use FTP over TLS
+useImplicitTls=Use Implicit TLS
 trustedCertificate=Trusted Certificate

--- a/src/main/resources/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration/help-useImplicitTls.html
+++ b/src/main/resources/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration/help-useImplicitTls.html
@@ -1,0 +1,25 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright (C) 2018 by Christian Janz
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<div>Use implicit FTP over TLS</div>


### PR DESCRIPTION
In certain firewall setups or with certain FTP servers you still have to use implicit FTPS. This pull request adds a config option for enabling implicit mode.