### PR TITLE
Set proper data channel protection for Implicit FTPS

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration.java
+++ b/src/main/java/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration.java
@@ -247,6 +247,7 @@ public class BapFtpHostConfiguration extends BPHostConfiguration<BapFtpClient, O
             exception(client, Messages.exception_connectFailed(getHostnameTrimmed(), getPort(), responseCode));
         }
         setDataTransferMode(ftpClient);
+        setDataChannelProtection(ftpClient);
     }
 
     private void setDataTransferMode(final FTPClient ftpClient) {
@@ -254,6 +255,14 @@ public class BapFtpHostConfiguration extends BPHostConfiguration<BapFtpClient, O
             ftpClient.enterLocalActiveMode();
         } else {
             ftpClient.enterLocalPassiveMode();
+        }
+    }
+
+    private void setDataChannelProtection(FTPClient ftpClient) throws IOException {
+        if (useImplicitTls && ftpClient instanceof FTPSClient) {
+            FTPSClient ftpsClient = (FTPSClient) ftpClient;
+            ftpsClient.execPBSZ(0);
+            ftpsClient.execPROT("P");
         }
     }
 


### PR DESCRIPTION
Some servers respond with an error response
"550 The message received was unexpected or badly formatted."
when not setting Data Channel Protection Level (PROT) to "Private (P)"
and not setting a value of 0 for Protection Buffer Size (PBSZ)

Unfortunately I encountered this problem after creating my previous pull request (https://github.com/jenkinsci/publish-over-ftp-plugin/pull/5), so I have to create this new pull request. Sorry for the inconvenience.