### PR TITLE
Data channel protection support for explicit TLS

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration.java
+++ b/src/main/java/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration.java
@@ -73,6 +73,7 @@ public class BapFtpHostConfiguration extends BPHostConfiguration<BapFtpClient, O
     private final boolean disableRemoteVerification;
     private boolean useFtpOverTls;
     private boolean useImplicitTls;
+    private boolean useDataChannelProtection;
     private String trustedCertificate;
 
     @DataBoundConstructor
@@ -95,6 +96,11 @@ public class BapFtpHostConfiguration extends BPHostConfiguration<BapFtpClient, O
     @DataBoundSetter
     public void setUseImplicitTls(final boolean useImplicitTls) {
         this.useImplicitTls = useImplicitTls;
+    }
+
+    @DataBoundSetter
+    public void setUseDataChannelProtection(final boolean useDataChannelProtection) {
+        this.useDataChannelProtection = useDataChannelProtection;
     }
 
     @DataBoundSetter
@@ -129,6 +135,10 @@ public class BapFtpHostConfiguration extends BPHostConfiguration<BapFtpClient, O
 
     public boolean isUseImplicitTls() {
         return useImplicitTls;
+    }
+
+    public boolean isUseDataChannelProtection() {
+      return useDataChannelProtection;
     }
 
     public String getTrustedCertificate() {
@@ -261,7 +271,7 @@ public class BapFtpHostConfiguration extends BPHostConfiguration<BapFtpClient, O
     }
 
     private void setDataChannelProtection(FTPClient ftpClient) throws IOException {
-        if (useImplicitTls && ftpClient instanceof FTPSClient) {
+        if ((useImplicitTls | useDataChannelProtection) && ftpClient instanceof FTPSClient) {
             FTPSClient ftpsClient = (FTPSClient) ftpClient;
             ftpsClient.execPBSZ(0);
             ftpsClient.execPROT("P");

--- a/src/main/java/jenkins/plugins/publish_over_ftp/descriptor/BapFtpHostConfigurationDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ftp/descriptor/BapFtpHostConfigurationDescriptor.java
@@ -76,12 +76,13 @@ public class BapFtpHostConfigurationDescriptor extends Descriptor<BapFtpHostConf
             @QueryParameter final int timeout, @QueryParameter final boolean useActiveData,
             @QueryParameter final String controlEncoding, @QueryParameter final boolean disableMakeNestedDirs,
             @QueryParameter final boolean disableRemoteVerification, @QueryParameter final boolean useFtpOverTls,
-            @QueryParameter final boolean useImplicitTls, @QueryParameter final String trustedCertificate) {
+            @QueryParameter final boolean useImplicitTls, @QueryParameter final boolean useDataChannelProtection,
+            @QueryParameter final String trustedCertificate) {
         final BapFtpPublisherPlugin.Descriptor pluginDescriptor = Jenkins.getInstance().getDescriptorByType(
                 BapFtpPublisherPlugin.Descriptor.class);
         return pluginDescriptor.doTestConnection(name, hostname, username, encryptedPassword, remoteRootDir, port,
                 timeout, useActiveData, controlEncoding, disableMakeNestedDirs, disableRemoteVerification,
-                useFtpOverTls, useImplicitTls, trustedCertificate);
+                useFtpOverTls, useImplicitTls, useDataChannelProtection, trustedCertificate);
     }
 
     public jenkins.plugins.publish_over.view_defaults.HostConfiguration.Messages getCommonFieldNames() {

--- a/src/main/java/jenkins/plugins/publish_over_ftp/descriptor/BapFtpPublisherPluginDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_ftp/descriptor/BapFtpPublisherPluginDescriptor.java
@@ -132,12 +132,13 @@ public class BapFtpPublisherPluginDescriptor extends BuildStepDescriptor<Publish
             final String encryptedPassword, final String remoteRootDir, final int port, final int timeout,
             final boolean useActiveData, final String controlEncoding, final boolean disableMakeNestedDirs,
             final boolean disableRemoteVerification, final boolean useFtpOverTls, final boolean useImplicitTls,
-            final String trustedCertificate) {
+            final boolean useDataChannelProtection, final String trustedCertificate) {
         final BapFtpHostConfiguration hostConfig = new BapFtpHostConfiguration(name, hostname, username,
                 encryptedPassword, remoteRootDir, port, timeout, useActiveData, controlEncoding,
                 disableMakeNestedDirs, disableRemoteVerification);
         hostConfig.setUseFtpOverTls(useFtpOverTls);
         hostConfig.setUseImplicitTls(useImplicitTls);
+        hostConfig.setUseDataChannelProtection(useDataChannelProtection);
         hostConfig.setTrustedCertificate(trustedCertificate);
         return validateConnection(hostConfig, createDummyBuildInfo());
     }

--- a/src/main/resources/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration/config.jelly
+++ b/src/main/resources/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration/config.jelly
@@ -68,11 +68,14 @@
             <f:entry title="${%useImplicitTls}" field="useImplicitTls">
               <f:checkbox/>
             </f:entry>
+            <f:entry title="${%useDataChannelProtection}" field="useDataChannelProtection">
+              <f:checkbox/>
+            </f:entry>
             <f:entry title="${%trustedCertificate}" field="trustedCertificate">
               <f:textarea/>
             </f:entry>
           </f:advanced>
           <f:validateButton title="${m.test_title()}" progress="${m.test_progress()}" method="testConnection"
-                            with="name,hostname,username,encryptedPassword,remoteRootDir,port,timeout,useActiveData,controlEncoding,disableRemoteVerification,useFtpOverTls,useImplicitTls,trustedCertificate"/>
+                            with="name,hostname,username,encryptedPassword,remoteRootDir,port,timeout,useActiveData,controlEncoding,disableRemoteVerification,useFtpOverTls,useImplicitTls,useDataChannelProtection,trustedCertificate"/>
 
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration/config.properties
+++ b/src/main/resources/jenkins/plugins/publish_over_ftp/BapFtpHostConfiguration/config.properties
@@ -28,4 +28,5 @@ disableMakeNestedDirs=Don''t make nested dirs
 disableRemoteVerification=Disables Remote Verification
 useFtpOverTls=Use FTP over TLS
 useImplicitTls=Use Implicit TLS
+useDataChannelProtection=Use Data Channel Protection
 trustedCertificate=Trusted Certificate


### PR DESCRIPTION
Currently data channel protection is only available for implicit TLS. This can also be required by FTP servers in explicit TLS mode (e.g. QuFTP on QNAS devices even don't allow to configure or disable that).

With my changes, the default behavior is still the same but there is now an additional option to enable data channel protection for explicit TLS.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did